### PR TITLE
CICD updates around packing/pushing NuGet packages

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,8 @@ name: Build, test, and deploy
 
 on:
   push:
-    - '**'
+    branches:
+      - '**'
 
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: Build, test, and deploy
 
 on:
   push:
-    branches: [ main ]
+    - '**'
 
 jobs:
   build:
@@ -23,19 +23,15 @@ jobs:
       run: dotnet restore
     
     - name: Build
-      run: dotnet build -c Release --no-restore
+      run: dotnet build --no-restore
     
     - name: Test
-      run: dotnet test -c Release --no-build --verbosity normal --filter "Category!=LongRunning"
+      run: dotnet test --no-restore --no-build --verbosity normal --filter "Category!=LongRunning"
 
-    - name: Publish Orleans.SyncWork to NuGet
-      uses: brandedoutcast/publish-nuget@v2.5.2
-      with:
-          PROJECT_FILE_PATH: src/Orleans.SyncWork/Orleans.SyncWork.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-          NUGET_SOURCE: https://api.nuget.org
-          PACKAGE_NAME: Orleans.SyncWork
-          #VERSION_FILE_PATH: src/Orleans.SyncWork/Orleans.SyncWork.csproj
-          #VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-          VERSION_STATIC: 1.0.0
-          INCLUDE_SYMBOLS: true
+    - name: Pack
+      run: dotnet pack src/Orleans.SyncWork/Orleans.SyncWork.csproj --no-restore --no-build --include-symbols --configuration Release -p:SymbolPackageFormat=snupkg -o .
+
+    # We should theoretically need to skip duplicates in instances where "the same commit" is pushed to multiple branches, with no other changes.
+    # This would seemingly cause the same GitVersioning commit history to arrive at the same semver version?
+    - name: Push to NuGet
+      run: dotnet nuget push *.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,9 +2,10 @@ name: Build, test, and deploy
 
 on:
   push:
-    # Do I want to build and push packages for each commit, or only on specific branches like main and "RELEASE/v*"? I'm not sure yet...
     branches:
-      - '**'
+      - 'main'
+      - 'RELEASE/v**'
+
 
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,6 +2,7 @@ name: Build, test, and deploy
 
 on:
   push:
+    # Do I want to build and push packages for each commit, or only on specific branches like main and "RELEASE/v*"? I'm not sure yet...
     branches:
       - '**'
 
@@ -24,13 +25,13 @@ jobs:
       run: dotnet restore
     
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build -c Release --no-restore
     
     - name: Test
-      run: dotnet test --no-restore --no-build --verbosity normal --filter "Category!=LongRunning"
+      run: dotnet test -c Release --no-restore --no-build --verbosity normal --filter "Category!=LongRunning"
 
     - name: Pack
-      run: dotnet pack src/Orleans.SyncWork/Orleans.SyncWork.csproj --no-restore --no-build --include-symbols --configuration Release -p:SymbolPackageFormat=snupkg -o .
+      run: dotnet pack src/Orleans.SyncWork/Orleans.SyncWork.csproj --c Release --no-restore --no-build --include-symbols -p:SymbolPackageFormat=snupkg -o .
 
     # We should theoretically need to skip duplicates in instances where "the same commit" is pushed to multiple branches, with no other changes.
     # This would seemingly cause the same GitVersioning commit history to arrive at the same semver version?

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet test -c Release --no-restore --no-build --verbosity normal --filter "Category!=LongRunning"
 
     - name: Pack
-      run: dotnet pack src/Orleans.SyncWork/Orleans.SyncWork.csproj --c Release --no-restore --no-build --include-symbols -p:SymbolPackageFormat=snupkg -o .
+      run: dotnet pack src/Orleans.SyncWork/Orleans.SyncWork.csproj -c Release --no-restore --no-build --include-symbols -p:SymbolPackageFormat=snupkg -o .
 
     # We should theoretically need to skip duplicates in instances where "the same commit" is pushed to multiple branches, with no other changes.
     # This would seemingly cause the same GitVersioning commit history to arrive at the same semver version?

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <OrleansSyncWorkVersion Condition=" '$(OrleansSyncWorkVersion)'=='' ">0.1.0</OrleansSyncWorkVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <Version>3.4.244</Version>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0-prerelease",
+  "version": "1.1-prerelease",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/RELEASE/v\\d+(?:\\.\\d+)?$"
@@ -11,7 +11,7 @@
     }
   },
   "release": {
-    "branchName" : "release/v{version}",
+    "branchName" : "RELEASE/v{version}",
     "versionIncrement" : "minor",
     "firstUnstableTag" : "prerelease"
   }

--- a/version.json
+++ b/version.json
@@ -1,13 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.0-prerelease",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
-    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+    "^refs/heads/RELEASE/v\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {
     "buildNumber": {
       "enabled": true
     }
+  },
+  "release": {
+    "branchName" : "release/v{version}",
+    "versionIncrement" : "minor",
+    "firstUnstableTag" : "prerelease"
   }
 }


### PR DESCRIPTION
* Updates CICD action with explicit nuget pack/push steps, as the action that was being used had some behaviors that weren't working as expected.
  * See #9 for more specifics
* Updates CICD action to only push packages from branches `main`, and `RELEASE/v*`

Closes #11, closes #9.