### PR TITLE
Organization (moved test cluster to own namespace)

### DIFF
--- a/samples/Orleans.SyncWork.Demo.Api.Benchmark/Benchy.cs
+++ b/samples/Orleans.SyncWork.Demo.Api.Benchmark/Benchy.cs
@@ -44,7 +44,7 @@ public class Benchy
     {
         var tasks = new List<Task>();
 
-        Parallel.For(0, TotalNumberPerBenchmark, i =>
+        Parallel.For(0, TotalNumberPerBenchmark, _ =>
         {
             tasks.Add(_passwordVerifier.VerifyPassword(IPasswordVerifier.PasswordHash, IPasswordVerifier.Password));
         });

--- a/samples/Orleans.SyncWork.Demo.Api.Benchmark/Program.cs
+++ b/samples/Orleans.SyncWork.Demo.Api.Benchmark/Program.cs
@@ -1,5 +1,4 @@
-﻿
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 using Orleans.SyncWork.Demo.Api.Benchmark;
 
 BenchmarkRunner.Run<Benchy>();

--- a/samples/Orleans.SyncWork.Demo.Api/OrleansConfigurationHelper.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/OrleansConfigurationHelper.cs
@@ -7,7 +7,6 @@ using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.SyncWork.Demo.Api.Services;
 using Orleans.SyncWork.Demo.Api.Services.Grains;
-using Orleans.SyncWork.Demo.Api.Services.TestGrains;
 using Orleans.SyncWork.ExtensionMethods;
 
 namespace Orleans.SyncWork.Demo.Api
@@ -64,11 +63,7 @@ namespace Orleans.SyncWork.Demo.Api
 
             builder.ConfigureServices(services =>
             {
-                services.AddSingleton<IHelloWorld, HelloWorld>();
                 services.AddSingleton<IPasswordVerifier, Services.PasswordVerifier>();
-                services.AddSingleton<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, Services.Grains.PasswordVerifier>();
-                services.AddSingleton<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>, GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable>();
-                services.AddSingleton<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>, GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable>();
             });
             return builder;
         }

--- a/samples/Orleans.SyncWork.Demo.Api/Services/Grains/HelloWorld.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/Services/Grains/HelloWorld.cs
@@ -2,7 +2,7 @@
 
 namespace Orleans.SyncWork.Demo.Api.Services.Grains
 {
-    public class HelloWorld : Grain, IHelloWorld, IGrain
+    public class HelloWorld : Grain, IHelloWorld
     {
         public Task<string> GetGreeting(string name)
         {

--- a/samples/Orleans.SyncWork.Demo.Api/Services/Grains/PasswordVerifier.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/Services/Grains/PasswordVerifier.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Orleans.SyncWork.Demo.Api.Services.Grains;
 
-public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVerifierResult>, IGrain
+public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVerifierResult>
 {
     private readonly IPasswordVerifier _passwordVerifier;
 
@@ -27,11 +27,11 @@ public class PasswordVerifier : SyncWorker<PasswordVerifierRequest, PasswordVeri
 }
 public class PasswordVerifierRequest
 {
-    public string Password { get; set; }
-    public string PasswordHash { get; set; }
+    public string Password { get; init; }
+    public string PasswordHash { get; init; }
 }
 
 public class PasswordVerifierResult
 {
-    public bool IsValid { get; set; }
+    public bool IsValid { get; init; }
 }

--- a/samples/Orleans.SyncWork.Demo.Api/Services/TestGrains/GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/Services/TestGrains/GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable.cs
@@ -11,7 +11,7 @@ public class TestGrainException : Exception
 
 public class TestDelayExceptionRequest
 {
-    public int MsDelayPriorToResult { get; set; }
+    public int MsDelayPriorToResult { get; init; }
 }
 
 public class TestDelayExceptionResult
@@ -27,6 +27,7 @@ public class GrainThatWaitsSetTimePriorToExceptionResultBecomingAvailable : Sync
 
     protected override async Task<TestDelayExceptionResult> PerformWork(TestDelayExceptionRequest request)
     {
+        _logger.LogInformation($"Waiting {request.MsDelayPriorToResult} on {this.IdentityString}");
         await Task.Delay(request.MsDelayPriorToResult);
 
         throw new TestGrainException("This is an expected exception, I'm testing for it!");

--- a/samples/Orleans.SyncWork.Demo.Api/Services/TestGrains/GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
+++ b/samples/Orleans.SyncWork.Demo.Api/Services/TestGrains/GrainThatWaitsSetTimePriorToSuccessResultBecomingAvailable.cs
@@ -6,14 +6,14 @@ namespace Orleans.SyncWork.Demo.Api.Services.TestGrains;
 
 public class TestDelaySuccessRequest
 {
-    public DateTime Started { get; set; }
-    public int MsDelayPriorToResult { get; set; }
+    public DateTime Started { get; init; }
+    public int MsDelayPriorToResult { get; init; }
 }
 
 public class TestDelaySuccessResult
 {
-    public DateTime Started { get; set; }
-    public DateTime Ended { get; set; }
+    public DateTime Started { get; init; }
+    public DateTime Ended { get; init; }
 
     public TimeSpan Duration => Ended - Started;
 }

--- a/src/Orleans.SyncWork/ExtensionMethods/SiloHostBuilderExtensions.cs
+++ b/src/Orleans.SyncWork/ExtensionMethods/SiloHostBuilderExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Hosting;
 
 namespace Orleans.SyncWork.ExtensionMethods;
@@ -28,10 +31,59 @@ public static class SiloHostBuilderExtensions
 
         builder.ConfigureServices(services =>
         {
-            var limitedConcurrencyLevelTaskScheduler = new LimitedConcurrencyLevelTaskScheduler(maxSyncWorkConcurrency);
-            services.AddSingleton(limitedConcurrencyLevelTaskScheduler);
+            services.AddSingleton(_ => new LimitedConcurrencyLevelTaskScheduler(maxSyncWorkConcurrency));
         });
 
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers the required <see cref="LimitedConcurrencyLevelTaskScheduler"/>, and scans marker assemblies for the
+    /// automatic registration of implementations against <see cref="ISyncWorker{TRequest,TResult}"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="ISiloHostBuilder"/> instance.</param>
+    /// <param name="maxSyncWorkConcurrency">
+    ///     The maximum amount of concurrent work to perform at a time.  
+    ///     The CPU cannot be "tapped out" with concurrent work lest Orleans experience timeouts.
+    /// </param>
+    /// <param name="markers">
+    ///     The assemblies to scan to find implementations of <see cref="ISyncWorker{TRequest,TResult}"/> to register.
+    /// </param>
+    /// <remarks>
+    /// 
+    ///     A "general" rule of thumb that I've had success with is using "Environment.ProcessorCount - 2" as the max concurrency.
+    /// 
+    /// </remarks>
+    /// <returns>The <see cref="ISiloHostBuilder"/> to allow additional fluent API chaining.</returns>
+    public static ISiloHostBuilder ConfigureSyncWorkAbstraction(this ISiloHostBuilder builder,
+        int maxSyncWorkConcurrency = 4, params Type[] markers)
+    {
+        builder.ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ISyncWorkAbstractionMarker).Assembly).WithReferences());
+
+        builder.ConfigureServices(services =>
+        {
+            services.AddSingleton(_ => new LimitedConcurrencyLevelTaskScheduler(maxSyncWorkConcurrency));
+        });
+        
+        foreach (var marker in markers)
+        {
+            var assembly = marker.Assembly;
+            var grainImplementations = assembly.ExportedTypes
+                .Where(type =>
+                {
+                    var genericInterfaceTypes = type.GetInterfaces().Where(x => x.IsGenericType).ToList();
+                    var implementationSyncWorkType = genericInterfaceTypes
+                        .Any(x => x.GetGenericTypeDefinition() == typeof(ISyncWorker<,>));
+
+                    return !type.IsInterface && !type.IsAbstract && implementationSyncWorkType;
+                }).ToList();
+
+            var serviceDescriptors = grainImplementations.Select(grainImplementation =>
+                new ServiceDescriptor(grainImplementation, grainImplementation, ServiceLifetime.Transient));
+            
+            builder.ConfigureServices(x => x.TryAdd(serviceDescriptors));
+        }
+        
         return builder;
     }
 }

--- a/src/Orleans.SyncWork/ISyncWorkAbstractionMarker.cs
+++ b/src/Orleans.SyncWork/ISyncWorkAbstractionMarker.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Orleans.SyncWork;
 
-namespace Orleans.SyncWork
+/// <summary>
+/// Marker interface used for assembly scanning
+/// </summary>
+public interface ISyncWorkAbstractionMarker
 {
-    /// <summary>
-    /// Marker interface used for assembly scanning
-    /// </summary>
-    public interface ISyncWorkAbstractionMarker
-    {
-    }
 }

--- a/src/Orleans.SyncWork/LimitedConcurrencyLevelTaskScheduler.cs
+++ b/src/Orleans.SyncWork/LimitedConcurrencyLevelTaskScheduler.cs
@@ -19,11 +19,11 @@ public class LimitedConcurrencyLevelTaskScheduler : TaskScheduler
     [ThreadStatic]
     private static bool _currentThreadIsProcessingItems;
     /// <summary>The list of tasks to be executed.</summary>
-    private readonly LinkedList<Task> _tasks = new LinkedList<Task>(); // protected by lock(_tasks)
+    private readonly LinkedList<Task> _tasks = new(); // protected by lock(_tasks)
     /// <summary>The maximum concurrency level allowed by this scheduler.</summary>
     private readonly int _maxDegreeOfParallelism;
     /// <summary>Whether the scheduler is currently processing work items.</summary>
-    private int _delegatesQueuedOrRunning = 0; // protected by lock(_tasks)
+    private int _delegatesQueuedOrRunning; // protected by lock(_tasks)
 
     /// <summary>
     /// Initializes an instance of the LimitedConcurrencyLevelTaskScheduler class with the

--- a/src/Orleans.SyncWork/SyncWorker.cs
+++ b/src/Orleans.SyncWork/SyncWorker.cs
@@ -15,7 +15,7 @@ namespace Orleans.SyncWork;
 /// </summary>
 /// <typeparam name="TRequest">The request type (arguments/parameters) for a long running piece of work.</typeparam>
 /// <typeparam name="TResult">The result/response for a long running piece of work.</typeparam>
-public abstract class SyncWorker<TRequest, TResult> : Grain, ISyncWorker<TRequest, TResult>, IGrain
+public abstract class SyncWorker<TRequest, TResult> : Grain, ISyncWorker<TRequest, TResult>
 {
     protected readonly ILogger _logger;
     private readonly LimitedConcurrencyLevelTaskScheduler _limitedConcurrencyScheduler;

--- a/src/Orleans.SyncWork/SyncWorkerExtensions.cs
+++ b/src/Orleans.SyncWork/SyncWorkerExtensions.cs
@@ -46,10 +46,9 @@ public static class SyncWorkerExtensions
         await worker.Start(request);
         await Task.Delay(100);
 
-        SyncWorkStatus status;
         while (true)
         {
-            status = await worker.GetWorkStatus();
+            var status = await worker.GetWorkStatus();
 
             switch (status)
             {

--- a/test/Orleans.SyncWork.Tests/HelloWorldTests.cs
+++ b/test/Orleans.SyncWork.Tests/HelloWorldTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using Orleans.SyncWork.Demo.Api.Services.Grains;
+using Orleans.SyncWork.Tests.TestClusters;
 using Xunit;
 
 namespace Orleans.SyncWork.Tests;
@@ -18,7 +19,7 @@ public class HelloWorldTests : ClusterTestBase
     [InlineData("Applesauce")]
     public async Task WhenGivenName_ShouldReturnNameWithinString(string name)
     {
-        var grain = _cluster.GrainFactory.GetGrain<IHelloWorld>(Guid.Empty);
+        var grain = Cluster.GrainFactory.GetGrain<IHelloWorld>(Guid.Empty);
         var result = await grain.GetGreeting(name);
 
         result.Should().Contain(name);

--- a/test/Orleans.SyncWork.Tests/SyncWorkerExtensionMethodTests.cs
+++ b/test/Orleans.SyncWork.Tests/SyncWorkerExtensionMethodTests.cs
@@ -4,13 +4,14 @@ using BCrypt.Net;
 using FluentAssertions;
 using Orleans.SyncWork.Demo.Api.Services;
 using Orleans.SyncWork.Demo.Api.Services.Grains;
+using Orleans.SyncWork.Tests.TestClusters;
 using Xunit;
 
 namespace Orleans.SyncWork.Tests;
 
 /// <summary>
-/// This test class is not *necessarily* specific the the <see cref="PasswordVerifier"/> grain. It is more
-/// intended to demonstrate the workings of the "flow" of using the <see cref="ISyncWorker{TRequest, TResult}"/>
+/// This test class is not *necessarily* specific the the <see cref="Orleans.SyncWork.Demo.Api.Services.PasswordVerifier"/> grain.
+/// It is more intended to demonstrate the workings of the "flow" of using the <see cref="ISyncWorker{TRequest, TResult}"/>
 /// as far as getting expected results and exceptions from the execution of the grain using the extension method(s)
 /// in <see cref="SyncWorkerExtensions"/>.
 /// </summary>
@@ -21,7 +22,7 @@ public class SyncWorkerExtensionMethodTests : ClusterTestBase
     [Fact]
     public async Task WhenGivenValidPasswordAndHash_ShouldVerify()
     {
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
 
         var request = new PasswordVerifierRequest
         {
@@ -37,7 +38,7 @@ public class SyncWorkerExtensionMethodTests : ClusterTestBase
     [Fact]
     public async Task WhenGivenInvalidPasswordAndHash_ShouldNotVerify()
     {
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
 
         var request = new PasswordVerifierRequest
         {
@@ -53,7 +54,7 @@ public class SyncWorkerExtensionMethodTests : ClusterTestBase
     [Fact]
     public async Task WhenGivenBadHashFormat_ShouldException()
     {
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
 
         var request = new PasswordVerifierRequest
         {

--- a/test/Orleans.SyncWork.Tests/SyncWorkerTests.cs
+++ b/test/Orleans.SyncWork.Tests/SyncWorkerTests.cs
@@ -7,6 +7,7 @@ using Orleans.SyncWork.Demo.Api.Services;
 using Orleans.SyncWork.Demo.Api.Services.Grains;
 using Orleans.SyncWork.Demo.Api.Services.TestGrains;
 using Orleans.SyncWork.Exceptions;
+using Orleans.SyncWork.Tests.TestClusters;
 using Orleans.SyncWork.Tests.XUnitTraits;
 using Xunit;
 
@@ -34,7 +35,7 @@ public class SyncWorkerTests : ClusterTestBase
         };
         for (var i = 0; i < totalInvokes; i++)
         {
-            var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+            var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
             tasks.Add(grain.StartWorkAndPollUntilResult(request));
         }
 
@@ -61,7 +62,7 @@ public class SyncWorkerTests : ClusterTestBase
         };
         for (var i = 0; i < 10_000; i++)
         {
-            var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
+            var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<PasswordVerifierRequest, PasswordVerifierResult>>(Guid.NewGuid());
             tasks.Add(grain.StartWorkAndPollUntilResult(request));
         }
 
@@ -73,7 +74,7 @@ public class SyncWorkerTests : ClusterTestBase
     [Fact]
     public async Task WhenGrainNotStarted_ShouldHaveStatusNotRunning()
     {
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
         var result = await grain.GetWorkStatus();
 
         result.Should().Be(Enums.SyncWorkStatus.NotStarted);
@@ -83,7 +84,7 @@ public class SyncWorkerTests : ClusterTestBase
     public async Task WhenGrainStartedButWorkNotCompleted_ShouldReturnStatusRunningOnGetStatus()
     {
         var delay = 2500;
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
         await grain.Start(new TestDelaySuccessRequest()
         {
             Started = DateTime.UtcNow,
@@ -105,7 +106,7 @@ public class SyncWorkerTests : ClusterTestBase
     public async Task WhenGrainStartedButWorkNotCompleted_ShouldThrowWhenAttemptingToRetrieveResults()
     {
         var delay = 5000;
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
         await grain.Start(new TestDelaySuccessRequest()
         {
             Started = DateTime.UtcNow,
@@ -121,7 +122,7 @@ public class SyncWorkerTests : ClusterTestBase
     public async Task WhenGrainExceptionStartedButWorkNotCompleted_ShouldReturnStatusRunningOnGetStatus()
     {
         var delay = 2500;
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
         await grain.Start(new TestDelayExceptionRequest()
         {
             MsDelayPriorToResult = delay
@@ -142,7 +143,7 @@ public class SyncWorkerTests : ClusterTestBase
     public async Task WhenExceptionGrainStartedButWorkNotCompleted_ShouldThrowWhenAttemptingToRetrieveResults()
     {
         var delay = 5000;
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
         await grain.Start(new TestDelayExceptionRequest()
         {
             MsDelayPriorToResult = delay
@@ -164,7 +165,7 @@ public class SyncWorkerTests : ClusterTestBase
             MsDelayPriorToResult = 10
         };
 
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
         var result = await grain.StartWorkAndPollUntilResult(request);
 
         result.Started.Should().Be(started);
@@ -181,7 +182,7 @@ public class SyncWorkerTests : ClusterTestBase
             MsDelayPriorToResult = 10
         };
 
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelaySuccessRequest, TestDelaySuccessResult>>(Guid.NewGuid());
         await grain.Start(request);
 
         var status = await grain.GetWorkStatus();
@@ -204,7 +205,7 @@ public class SyncWorkerTests : ClusterTestBase
             MsDelayPriorToResult = 10
         };
 
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
         var action = new Func<Task>(async () => await grain.StartWorkAndPollUntilResult(request));
 
         await action.Should().ThrowAsync<TestGrainException>();
@@ -218,7 +219,7 @@ public class SyncWorkerTests : ClusterTestBase
             MsDelayPriorToResult = 10
         };
 
-        var grain = _cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
+        var grain = Cluster.GrainFactory.GetGrain<ISyncWorker<TestDelayExceptionRequest, TestDelayExceptionResult>>(Guid.NewGuid());
         await grain.Start(request);
 
         var status = await grain.GetWorkStatus();

--- a/test/Orleans.SyncWork.Tests/TestClusters/ClusterCollection.cs
+++ b/test/Orleans.SyncWork.Tests/TestClusters/ClusterCollection.cs
@@ -1,8 +1,8 @@
 ﻿using Xunit;
 
-namespace Orleans.SyncWork.Tests;
+namespace Orleans.SyncWork.Tests.TestClusters;
 
-[CollectionDefinition(ClusterCollection.Name)]
+[CollectionDefinition(Name)]
 public class ClusterCollection : ICollectionFixture<ClusterFixture>
 {
     public const string Name = "ClusterCollection";

--- a/test/Orleans.SyncWork.Tests/TestClusters/ClusterFixture.cs
+++ b/test/Orleans.SyncWork.Tests/TestClusters/ClusterFixture.cs
@@ -4,14 +4,14 @@ using Orleans.Hosting;
 using Orleans.SyncWork.Demo.Api.Services;
 using Orleans.TestingHost;
 
-namespace Orleans.SyncWork.Tests;
+namespace Orleans.SyncWork.Tests.TestClusters;
 
 /// <summary>
 /// Fixture for creating and eventually disposing a <see cref="TestCluster"/> for use in testing.
 /// </summary>
 public class ClusterFixture : IDisposable
 {
-    public class TestSiloConfigurations : ISiloConfigurator
+    private class TestSiloConfigurations : ISiloConfigurator
     {
         public void Configure(ISiloBuilder siloBuilder)
         {
@@ -53,5 +53,5 @@ public class ClusterFixture : IDisposable
         Cluster.StopAllSilos();
     }
 
-    public TestCluster Cluster { get; private set; }
+    public TestCluster Cluster { get; }
 }

--- a/test/Orleans.SyncWork.Tests/TestClusters/ClusterTestBase.cs
+++ b/test/Orleans.SyncWork.Tests/TestClusters/ClusterTestBase.cs
@@ -1,7 +1,7 @@
 ﻿using Orleans.TestingHost;
 using Xunit;
 
-namespace Orleans.SyncWork.Tests;
+namespace Orleans.SyncWork.Tests.TestClusters;
 
 /// <summary>
 /// An abstract class containing a <see cref="TestCluster"/> for use in tests against
@@ -10,10 +10,10 @@ namespace Orleans.SyncWork.Tests;
 [Collection(ClusterCollection.Name)]
 public abstract class ClusterTestBase
 {
-    protected readonly TestCluster _cluster;
+    protected readonly TestCluster Cluster;
 
-    public ClusterTestBase(ClusterFixture fixture)
+    protected ClusterTestBase(ClusterFixture fixture)
     {
-        _cluster = fixture.Cluster;
+        Cluster = fixture.Cluster;
     }
 }


### PR DESCRIPTION
* Addressed various warnings/information messages about unused variables, usings, etc
* Removed explicit grain registrations from IOC setup.
  * Was thinking explicit registration was needed (hence #10), but since it isn't, closes #10.