### PR TITLE
Now targeting netstandard rather than latest net6

### DIFF
--- a/src/Orleans.SyncWork/Orleans.SyncWork.csproj
+++ b/src/Orleans.SyncWork/Orleans.SyncWork.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    
     <Authors>Kritner</Authors>
     <Company>Kritner</Company>
     <Description>Provides an abstract base class grain to use for dispatching potentially long running, CPU bound work to an Orleans cluster.</Description>
@@ -14,22 +20,24 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackageProjectUrl>https://github.com/Kritner/Orleans.SyncWork</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Kritner/Orleans.SyncWork</RepositoryUrl>
 
     <Version>1.0.0</Version>
-    
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.5.1" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.5.1" />
-    <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.5.1" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.5.1">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Added Microsoft.SourceLink.GitHub from https://github.com/dotnet/sourcelink
* Reduced the Orleans dependencies to 2.1.0 as the minimum version